### PR TITLE
Fix: 32bit systems trying to get SysWOW64 directory

### DIFF
--- a/Source/Reloaded.Injector/Shellcode.cs
+++ b/Source/Reloaded.Injector/Shellcode.cs
@@ -68,7 +68,7 @@ namespace Reloaded.Injector
 
             // We need to change the module path if 32bit process; because the given path is not true,
             // it is being actively redirected by Windows on Windows 64 (WoW64)
-            if (_machineType == MachineType.I386)
+            if (_machineType == MachineType.I386 && Environment.Is64BitOperatingSystem)
             {
                 StringBuilder builder = new StringBuilder(256);
                 GetSystemWow64Directory(builder, (uint)builder.Capacity);


### PR DESCRIPTION
On 32bit windows GetSystemWow64Directory doesnt do anything, basically leaving builder empty after execution.
That leads to a file not found error while trying to pass "\\kernel32.dll" string to PeFile constructor
Since 32bit windows has only one kenel32 this codepath shouldn't be executed