### PR TITLE
 Library updates and compat fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.cs]
+csharp_new_line_before_open_brace                                        = all
+end_of_line = crlf

--- a/Source/Reloaded.Injector/CompatUtils.cs
+++ b/Source/Reloaded.Injector/CompatUtils.cs
@@ -1,0 +1,154 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using Reloaded.Memory;
+using Reloaded.Memory.Buffers;
+using Reloaded.Memory.Buffers.Structs;
+using Reloaded.Memory.Structs;
+using Reloaded.Memory.Utilities;
+//using static Reloaded.Injector.Kernel32.Kernel32;
+using K32 = Reloaded.Memory.Native.Windows.Kernel32;
+
+namespace Reloaded.Injector {
+	internal static class CompatUtils { //for back compat with other reload modules
+
+		public static unsafe long AddBytes(this CircularBuffer buffer, Span<byte> bytes) {
+			fixed (byte* ptr = bytes) {
+				return (long)buffer.Add(ptr, (uint)bytes.Length);
+			}
+
+		}
+	}
+
+	public class PrivateMemoryBufferCompat : IDisposable {
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public MemoryAllocation Allocate(Process proc, nuint length, nuint baseStartAddy = 0) {
+
+			nuint num = K32.VirtualAllocEx(proc.Handle, baseStartAddy, length, K32.MEM_ALLOCATION_TYPE.MEM_COMMIT | K32.MEM_ALLOCATION_TYPE.MEM_RESERVE, K32.MEM_PROTECTION.PAGE_EXECUTE_READWRITE);
+			if (num != 0) {
+				return new MemoryAllocation(num, length);
+			}
+			throw new Exception();
+
+		}
+
+
+
+        public PrivateMemoryBufferCompat(Process proc, nuint size, bool isPrivateAlloc = false) {
+			IsPrivateAlloc = isPrivateAlloc;
+			memory = new ExternalMemory(proc);
+			if (!IsPrivateAlloc)
+				alloc = memory.Allocate(size);
+			else
+				palloc = Buffers.AllocatePrivateMemory(new Reloaded.Memory.Buffers.Structs.Params.BufferAllocatorSettings { TargetProcess = proc, MinAddress = Shellcode.minimumAddress, MaxAddress = (nuint)UInt64.MaxValue, Size = (uint)size, RetryCount = Shellcode.retryCount });
+		}
+        private bool IsPrivateAlloc;
+		public nuint BaseAddress => IsPrivateAlloc ? palloc.BaseAddress : alloc.Address;
+		public nuint AllocSize => IsPrivateAlloc ? palloc.Size : alloc.Length;
+		private MemoryAllocation alloc;
+		private PrivateAllocation palloc;
+		//private PrivateAllocation memory;
+		private ExternalMemory memory;
+		private bool disposedValue;
+		private nuint nextFreeBlockOffset = 0;
+
+		protected virtual void Dispose(bool disposing) {
+			if (!disposedValue) {
+				if (disposing) {
+
+				}
+				if (IsPrivateAlloc)
+					palloc.Dispose();
+				else
+					memory.Free(alloc);
+
+				disposedValue = true;
+			}
+		}
+
+		private object writeLock = new();
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static nuint GetSize<T>(bool marshalElement) {
+			if (!marshalElement)
+				return (nuint)Unsafe.SizeOf<T>();
+
+
+			return (nuint)Marshal.SizeOf<T>();
+		}
+
+		//
+		// Summary:
+		//     Writes your own structure address into process' memory and gives you the address
+		//     to which the structure has been directly written to.
+		//
+		// Parameters:
+		//   bytesToWrite:
+		//     A structure to be converted into individual bytes to be written onto the buffer.
+		//
+		//   marshalElement:
+		//     Set this to true to marshal the given parameter before writing it to the buffer,
+		//     else false.
+		//
+		//   alignment:
+		//     The memory alignment of the item to be added to the buffer.
+		//
+		// Returns:
+		//     Pointer to the newly written structure in memory. Null pointer, if it cannot
+		//     fit into the buffer.
+		public nuint Add<TStructure>(ref TStructure bytesToWrite, bool marshalElement = false) where TStructure : unmanaged {
+			if (marshalElement)
+				return AddMarshalled(bytesToWrite);
+			var writePos = SecureWriteMemLoc(bytesToWrite, marshalElement);
+			memory.Write(writePos, bytesToWrite);
+			return writePos;
+		}
+		private nuint AddMarshalled<TStructure>(TStructure bytesToWrite) {
+			var writePos = SecureWriteMemLoc(bytesToWrite, true);
+			memory.WriteWithMarshalling(writePos, bytesToWrite);
+			return writePos;
+		}
+		private nuint SecureWriteMemLoc<TStructure>(TStructure bytesToWrite, bool marshalElement) => SecureWriteMemLoc(GetSize<TStructure>(marshalElement));
+
+		private nuint SecureWriteMemLoc(nuint size) {
+			lock (writeLock) {
+				var writePos = nextFreeBlockOffset;
+				if (size + nextFreeBlockOffset > AllocSize)
+					throw new InsufficientMemoryException($"Tried to allocate: {size} and total size for our allocation is: {AllocSize} and next free block offset: {nextFreeBlockOffset}");
+				nextFreeBlockOffset += size;
+				var addy = writePos + BaseAddress;
+				return addy;
+			}
+		}
+		public nuint Add<TStructure>(ref TStructure bytesToWrite) where TStructure : struct {
+			return AddMarshalled(bytesToWrite);
+		}
+
+		public nuint Add(Span<byte> bytesToWrite) => AddBytes(bytesToWrite);
+		public nuint AddBytes(Span<byte> bytesToWrite) {
+			var writePos = SecureWriteMemLoc((nuint)bytesToWrite.Length);
+			memory.WriteRaw(writePos, bytesToWrite);
+			return writePos;
+		}
+
+
+
+
+		// TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
+		~PrivateMemoryBufferCompat() {
+			// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+			Dispose(disposing: false);
+		}
+
+		public void Dispose() {
+			// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+			Dispose(disposing: true);
+			GC.SuppressFinalize(this);
+		}
+	}
+}
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member

--- a/Source/Reloaded.Injector/Reloaded.Injector.csproj
+++ b/Source/Reloaded.Injector/Reloaded.Injector.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0; NET472</TargetFrameworks>
@@ -13,9 +13,10 @@
     <RepositoryUrl>https://github.com/Reloaded-Project/Reloaded.Injector</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.2.5</Version>
+    <Version>1.2.117</Version>
     <Copyright>LGPLV3</Copyright>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
+	  <LangVersion>Preview</LangVersion>
     <PackageIcon>Icon.png</PackageIcon>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
@@ -32,12 +33,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="PeNet" Version="0.8.1" />
-    <PackageReference Include="Reloaded.Assembler" Version="1.0.14">
+    <PackageReference Include="PeNet" Version="4.0.1" />
+    <PackageReference Include="Reloaded.Assembler" Version="1.0.15">
       <IncludeAssets>All</IncludeAssets>
       <PrivateAssets>None</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Reloaded.Memory.Buffers" Version="2.0.0" />
+    <PackageReference Include="Reloaded.Memory.Buffers" Version="3.0.4" />
   </ItemGroup>
 
 </Project>

--- a/Source/Reloaded.Injector/Shellcode.cs
+++ b/Source/Reloaded.Injector/Shellcode.cs
@@ -1,15 +1,13 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
 using PeNet;
+using PeNet.Header.Pe;
 using Reloaded.Injector.Exceptions;
-using Reloaded.Injector.Interop;
 using Reloaded.Injector.Interop.Structures;
-using Reloaded.Memory.Buffers;
-using Reloaded.Memory.Sources;
-using Reloaded.Memory.Utilities;
+using Reloaded.Memory;
 using static Reloaded.Injector.Kernel32.Kernel32;
 
 namespace Reloaded.Injector
@@ -20,6 +18,11 @@ namespace Reloaded.Injector
     /// </summary>
     public class Shellcode : IDisposable
     {
+		public static nuint CircularBufferSize = 4096;
+		public static nuint PrivateBufferSize = 4096;//orig did 4096
+		public static bool AssemblyLargePtrFix = false;// THIS DOES NOT WORK but if the ptr to our memroy is too high the fasm call will fail so wil need to figure out a work around
+		internal const nuint minimumAddress = 65536u;
+		internal const int retryCount = 3;
         /* Setup/Build Shellcode */
         public  long        Kernel32Handle      { get; }                /* Address of Kernel32 in remote process. */
         public  long        LoadLibraryAddress  { get; private set; }   /* Address of LoadLibrary function. */
@@ -31,11 +34,12 @@ namespace Reloaded.Injector
 
         /* Temp Helpers */
         private Assembler.Assembler _assembler;     /* Provides JIT Assembly of x86/x64 mnemonics.        */
-        private PrivateMemoryBuffer _privateBuffer; /* Provides us with somewhere to write our shellcode. */
+        private PrivateMemoryBufferCompat _privateBuffer; /* Provides us with somewhere to write our shellcode. */
 
         /* Perm Helpers */
         private ExternalMemory      _memory;        /* Provides access to other process' memory.          */
-        private CircularBuffer      _circularBuffer;/* For passing in our parameters to shellcode.        */
+		private PrivateMemoryBufferCompat _circularBuffer; /* the actual circular buffer no longer works with external process memory */
+
         private Process             _targetProcess; /* The process we will be calling functions in.       */
 
         /* Final products. */ /* stdcall for x86, Microsoft for x64 */
@@ -52,10 +56,11 @@ namespace Reloaded.Injector
         /// <param name="targetProcess">Process inside which to execute.</param>
         public Shellcode(Process targetProcess)
         {
-            _privateBuffer  = new MemoryBufferHelper(targetProcess).CreatePrivateMemoryBuffer(4096);
+
+			_privateBuffer = new PrivateMemoryBufferCompat(targetProcess,PrivateBufferSize, true); 
             _assembler      = new Assembler.Assembler();
             _memory         = new ExternalMemory(targetProcess);
-            _circularBuffer = new CircularBuffer(4096, _memory);
+            _circularBuffer = new (targetProcess, CircularBufferSize);
             _targetProcess  = targetProcess;
 
             // Get arch of target process. 
@@ -188,17 +193,22 @@ namespace Reloaded.Injector
                 "sub rsp, 40",                        // Re-align stack to 16 byte boundary +32 shadow space
                 "mov rdx, qword [qword rcx + 8]",     // lpProcName
                 "mov rcx, qword [qword rcx + 0]",     // hModule
-                $"call qword [qword {getProcAddressPtr}]",
+                AssemblyLargePtrFix ? $"mov qword [qword {getProcAddressPtr}], rax": $"call qword [qword {getProcAddressPtr}]",// CreateRemoteThread lpParameter with string already in ECX.
+				
+				AssemblyLargePtrFix ? $"call rax" : "",
+
                 $"mov qword [qword 0x{_getProcAddressReturnValuePtr.ToString("X")}], rax",
                 "add rsp, 40",                        // Re-align stack to 16 byte boundary + shadow space.
                 "ret"                     // Restore stack ptr. (Callee cleanup)
             };
 
-
-            byte[] bytes = _assembler.Assemble(getProcAddress);
+			var bytes = GetASM("BuildGetProcAddress64", getProcAddress);
             _getProcAddressShellPtr = (long)_privateBuffer.Add(bytes);
         }
-
+		private byte[] GetASM(String for_what, params string[] lines) {
+            byte[] bytes = _assembler.Assemble(lines);
+			return bytes;
+		}
         private void BuildLoadLibraryW86()
         {
             // Using stdcall calling convention.
@@ -238,13 +248,14 @@ namespace Reloaded.Injector
             {
                 $"use64",
                 "sub rsp, 40",                                // Re-align stack to 16 byte boundary + shadow space.
-                $"call qword [qword {loadLibraryPtr}]", // CreateRemoteThread lpParameter with string already in ECX.
+                AssemblyLargePtrFix ? $"mov qword [qword {loadLibraryPtr}], rax" : $"call qword [qword {loadLibraryPtr}]", // CreateRemoteThread lpParameter with string already in ECX.  //seems to throw an error of value out of range for high bit addresses
+				AssemblyLargePtrFix ? $"call rax" : "", // CreateRemoteThread lpParameter with string already in ECX.
+
                 $"mov qword [qword 0x{_loadLibraryWReturnValuePtr.ToString("X")}], rax",
                 "add rsp, 40",                                // Re-align stack to 16 byte boundary + shadow space.
                 "ret"                                         // Restore stack ptr. (Callee cleanup)
             };
-
-            byte[] bytes = _assembler.Assemble(loadLibraryW);
+			var bytes = GetASM("BuildLoadLibraryW64", loadLibraryW);
             _loadLibraryWShellPtr = (long)_privateBuffer.Add(bytes);
         }
 
@@ -268,7 +279,8 @@ namespace Reloaded.Injector
         private long WriteNullTerminatedUnicodeString(string libraryPath)
         {
             byte[] libraryNameBytes = Encoding.Unicode.GetBytes(libraryPath + '\0');
-            return (long)_circularBuffer.Add(libraryNameBytes);
+            var adr =  _circularBuffer.Add(libraryNameBytes);
+			return (long)adr;
         }
 
         /* One off construction functions. */


### PR DESCRIPTION
Thanks for a great set of libraries! 
I was trying to track down various crash/failures with using it and one of the early things I did was update all the deps.  I don't know your projects super-well so the conversion is a bit rough and there is an added compat layer I added that may not be wanted (some things I couldn't find newer examples of).

I did find a few bugs in the process, one here related to .net detection also a larger DNNE bug that isn't really related other than from broader user of this library ( https://github.com/AaronRobinsonMSFT/DNNE/pull/178 ).

One thing I failed to do is get the library to work with 64 bit processes when the target address is greater than 4GB.  It has been a long time since ive done much assembly so I am sure something is wrong with my attempt (AssemblyLargePtrFix feature bool) but I am guessing one could fix it pretty easily.   Once I fixed the 32v64 bit detection I didn't need it (as the proper PEB header ended up having the libraries loaded lower).